### PR TITLE
`compress` action similar to Finder `Compress ...`

### DIFF
--- a/github/github_changelog_generator.rb
+++ b/github/github_changelog_generator.rb
@@ -44,7 +44,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :token,
                                        env_name: 'GITHUB_CHANGELOG_TOKEN',
-                                       description: 'GITHUB_CHANGELOG_TOKEN for Github ChangeLog Generator', #
+                                       description: 'GITHUB_CHANGELOG_TOKEN for Github ChangeLog Generator',
                                        verify_block: proc do |value|
                                          UI.user_error!('No GITHUB_API_TOKEN for Github ChangeLog Generator') unless value && !value.empty?
                                        end),

--- a/utils/compress.rb
+++ b/utils/compress.rb
@@ -1,0 +1,44 @@
+module Fastlane
+  module Actions
+    class CompressAction < Action
+      def self.run(params)
+        input = params[:input]
+        output = params[:output]
+
+        UI.message "Input: #{input}"
+        UI.message "Output: #{output}"
+        
+        sh "ditto -c -k --sequesterRsrc --keepParent #{input} #{output}"
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Compress similar to the Finder \"Compress ...\"'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :output,
+                                       description: 'Output archive name',
+                                       is_string: true,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :input,
+                                       description: 'Input folder to archive',
+                                       is_string: true,
+                                       optional: false)
+        ]
+      end
+
+      def self.authors
+        ['AndriiMoskvin']
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently used only for archiving framework OMSDK_Oath2.

[JIRA](https://jira.ouroath.com/browse/OMSDK-1691)
@aol-public/mobile-sdk-team Ready for review.